### PR TITLE
Fix: Implement RTL layout for sidebar and TOC

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -40,6 +40,7 @@ body {
 [dir="rtl"] .nextra-sidebar-container {
   border-right: none;
   border-left: 1px solid var(--nextra-colors-gray-200);
+  float: right;
 }
 
 [dir="rtl"] .nextra-sidebar-container > div {
@@ -50,6 +51,7 @@ body {
 [dir="rtl"] .nextra-toc {
   border-left: none;
   border-right: 1px solid var(--nextra-colors-gray-200);
+  float: left;
 }
 
 [dir="rtl"] .nextra-toc > div {


### PR DESCRIPTION
The sidebar and Table of Contents were not correctly positioned when the language was set to Arabic (RTL).

This change updates the CSS styles for RTL to:
- Float the sidebar to the right.
- Float the Table of Contents to the left.

This ensures that the main layout components are mirrored correctly for RTL languages.