### PR TITLE
I attempted to fix the RTL layout using Flexbox on the main element.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -37,10 +37,14 @@ body {
   text-align: right;
 }
 
+[dir="rtl"] main {
+  display: flex;
+  flex-direction: row-reverse;
+}
+
 [dir="rtl"] .nextra-sidebar-container {
   border-right: none;
   border-left: 1px solid var(--nextra-colors-gray-200);
-  float: right;
 }
 
 [dir="rtl"] .nextra-sidebar-container > div {
@@ -51,7 +55,6 @@ body {
 [dir="rtl"] .nextra-toc {
   border-left: none;
   border-right: 1px solid var(--nextra-colors-gray-200);
-  float: left;
 }
 
 [dir="rtl"] .nextra-toc > div {


### PR DESCRIPTION
This involved applying `display: flex;` and `flex-direction: row-reverse;` to the `main` HTML element when the language is set to Arabic (RTL).

This was an attempt to correctly position the sidebar to the right and the Table of Contents to the left for RTL languages by reversing the order of the main layout components.